### PR TITLE
chore: change decimal to `decimals`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -210,7 +210,7 @@ components:
       required: 
         - label
         - address
-        - decimal
+        - decimals
         - iconHash
       properties:
         label: 
@@ -219,7 +219,7 @@ components:
           maxLength: 64
         address:
           $ref: "#/components/schemas/Address"
-        decimal: 
+        decimals: 
           type: string
           pattern: '^[1-9][0-9]$'
           description: Decimal for token

--- a/src/tests/test.validation.ts
+++ b/src/tests/test.validation.ts
@@ -176,7 +176,7 @@ const PASS_GRANTS: IGrantCreateRequest[] = [
 			token: {
 				label: 'WMATIC',
 				address: '0xA0A2BC123456643222323232323292',
-				decimal: '18',
+				decimals: '18',
 				iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco'
 			}
 		},
@@ -291,7 +291,7 @@ const PASS_WORKSPACE_UPDATES: IWorkspaceUpdateRequest[] = [
 			{ name: 'discord', value: chance.url() }
 		],
 		tokens: [
-			{ label: 'WMATIC', address: '0x95b58a6bff3d14b7db2f5cb5f0ad413dc2940658', decimal: '18', iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco' },
+			{ label: 'WMATIC', address: '0x95b58a6bff3d14b7db2f5cb5f0ad413dc2940658', decimals: '18', iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco' },
 		]
 	},
 ]

--- a/src/types/gen.ts
+++ b/src/types/gen.ts
@@ -62,7 +62,7 @@ export interface components {
        * Format: integer
        * @description Decimal for token
        */
-      decimal: string;
+      decimals: string;
       /** @description IPFS hash of token icon */
       iconHash: string;
     };


### PR DESCRIPTION
Changed `Token` property `decimal` to `decimals` so that it is aligned with the properties present in `chainInfo.ts` file