### PR TITLE
fix: fix decimal regex pattern

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -221,7 +221,7 @@ components:
           $ref: "#/components/schemas/Address"
         decimal: 
           type: string
-          pattern: '^[1-9][0-9]$'
+          pattern: '^[1-9]?\d{1}$'
           description: Decimal for token
           format: integer
           maxLength: 4

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -221,7 +221,7 @@ components:
           $ref: "#/components/schemas/Address"
         decimal: 
           type: string
-          pattern: '^[1-9]?\d{1}$'
+          pattern: '^[1-9][0-9]{0,2}'
           description: Decimal for token
           format: integer
           maxLength: 4

--- a/src/tests/test.validation.ts
+++ b/src/tests/test.validation.ts
@@ -172,11 +172,11 @@ const PASS_GRANTS: IGrantCreateRequest[] = [
 		details: chance.paragraph(),
 		reward: {
 			committed: '100',
-			asset: '0xA0A2BC123456643222323232323292',
+			asset: '0xE3D997D569b5b03B577C6a2Edd1d2613FE776cb0',
 			token: {
-				label: 'WMATIC',
-				address: '0xA0A2BC123456643222323232323292',
-				decimal: '18',
+				label: 'BDEV',
+				address: '0xE3D997D569b5b03B577C6a2Edd1d2613FE776cb0',
+				decimal: '8',
 				iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco'
 			}
 		},
@@ -291,7 +291,7 @@ const PASS_WORKSPACE_UPDATES: IWorkspaceUpdateRequest[] = [
 			{ name: 'discord', value: chance.url() }
 		],
 		tokens: [
-			{ label: 'WMATIC', address: '0x95b58a6bff3d14b7db2f5cb5f0ad413dc2940658', decimal: '18', iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco' },
+			{ label: 'BDEV', address: '0xE3D997D569b5b03B577C6a2Edd1d2613FE776cb0', decimal: '8', iconHash: 'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco' },
 		]
 	},
 ]


### PR DESCRIPTION
The current decimal regex pattern was able to accept only two-digit values. Changed it to take one-digit values as well.