### PR TITLE
feat: fundingBreakdown optional

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -461,7 +461,6 @@ components:
         - applicantEmail
         - projectName
         - projectDetails
-        - fundingBreakdown
       properties:
         applicantName:
           $ref: '#/components/schemas/GrantField'

--- a/src/types/gen.ts
+++ b/src/types/gen.ts
@@ -155,7 +155,7 @@ export interface components {
       applicantEmail: components["schemas"]["GrantField"];
       projectName: components["schemas"]["GrantField"];
       projectDetails: components["schemas"]["GrantField"];
-      fundingBreakdown: components["schemas"]["GrantField"];
+      fundingBreakdown?: components["schemas"]["GrantField"];
     } & { [key: string]: components["schemas"]["GrantField"] };
     GrantReward: {
       committed: components["schemas"]["Amount"];


### PR DESCRIPTION
This PR removes `fundingBreakdown` from required properties for `GrantFieldMap`

_Note: This feature has been integrated to onboard OCEAN protocol_